### PR TITLE
fix: serve subcommand passes model path via --model, not as positional (#11)

### DIFF
--- a/homebrew/vllm-swift.rb
+++ b/homebrew/vllm-swift.rb
@@ -85,7 +85,14 @@ class VllmSwift < Formula
       case "${1:-}" in
         serve)
           shift
-          exec "$VENV_PYTHON" -m vllm.entrypoints.openai.api_server "$@"
+          # README documents `vllm-swift serve <model> [args]` — the model is
+          # the first positional. vllm.entrypoints.openai.api_server takes
+          # --model X as a flag, NOT a positional, so without this rewrite
+          # the path was getting silently dropped and vLLM was falling back
+          # to its placeholder default (Qwen/Qwen3-0.6B). See #11.
+          MODEL="${1:?Usage: vllm-swift serve <model-path-or-hf-id> [vllm args...]}"
+          shift
+          exec "$VENV_PYTHON" -m vllm.entrypoints.openai.api_server --model "$MODEL" "$@"
           ;;
         download)
           shift

--- a/scripts/build_bottle.sh
+++ b/scripts/build_bottle.sh
@@ -112,7 +112,14 @@ case "${1:-}" in
   serve)
     _ensure_venv
     shift
-    exec "$VENV_DIR/bin/python3" -m vllm.entrypoints.openai.api_server "$@"
+    # README documents `vllm-swift serve <model> [args]` — the model is the first
+    # positional. vllm.entrypoints.openai.api_server's argparse maps a stray
+    # positional to the deprecated `model_tag` slot, NOT to ModelConfig.model,
+    # so without this rewrite the user's path was getting silently dropped and
+    # vLLM was falling back to its placeholder default (Qwen/Qwen3-0.6B). See #11.
+    MODEL="${1:?Usage: vllm-swift serve <model-path-or-hf-id> [vllm args...]}"
+    shift
+    exec "$VENV_DIR/bin/python3" -m vllm.entrypoints.openai.api_server --model "$MODEL" "$@"
     ;;
   download)
     _ensure_venv


### PR DESCRIPTION
Fixes #11.

## Bug

The `vllm-swift serve` wrapper was forwarding the user's positional model path straight through to `vllm.entrypoints.openai.api_server`:

```bash
serve)
  _ensure_venv
  shift
  exec "$VENV_DIR/bin/python3" -m vllm.entrypoints.openai.api_server "$@"
  ;;
```

vLLM 0.19.1's argparse maps a stray positional to the deprecated `model_tag` slot, NOT to the `ModelConfig.model` field that drives the actual engine. The user's path was silently dropped and vLLM fell back to its built-in placeholder (`Qwen/Qwen3-0.6B`).

## Reproduction (M5 Max, vllm-swift v0.3.0 Homebrew bottle)

```bash
vllm-swift serve ~/models/Qwen3-0.6B-4bit --max-model-len 1024 --port 8765
```

Pre-fix log:
```
INFO ... [utils.py:233] non-default args: {'model_tag': '/Users/tom/models/Qwen3-0.6B-4bit', 'port': 8765, 'max_model_len': 1024}
INFO ... [core.py:105] Initializing a V1 LLM engine (v0.19.1) with config: model='Qwen/Qwen3-0.6B', ..., served_model_name=Qwen/Qwen3-0.6B
```

Post-fix log:
```
INFO ... [utils.py:233] non-default args: {'port': 8765, 'model': '/Users/tom/models/Qwen3-0.6B-4bit', 'max_model_len': 1024}
INFO ... [core.py:105] Initializing a V1 LLM engine (v0.19.1) with config: model='/Users/tom/models/Qwen3-0.6B-4bit', ..., served_model_name=/Users/tom/models/Qwen3-0.6B-4bit
INFO ... Application startup complete.
```

## Fix

Rewrite the wrapper to consume `$1` as `MODEL` and pass `--model "$MODEL"` explicitly to vLLM. Same change in two places:

- `scripts/build_bottle.sh` — generates the wrapper that ships in the Homebrew bottle (this is what the installed `vllm-swift` actually contains).
- `homebrew/vllm-swift.rb` — formula source for from-source installs.

Both are required because the formula's wrapper template diverged from the bottle generator at some point.

## On the second half of #11 (Python `LLM(model=...)` path)

Defilan also reported the Python API failing the same way. I reproduced his exact script and confirmed it's a **separate** issue: missing `if __name__ == '__main__':` guard around the `LLM(...)` construction. With macOS's spawn-based multiprocessing, the EngineCore subprocess re-imports the user's script, which tries to construct `LLM` again, and the recursive spawn handshake degrades the child's vLLM config to defaults — at which point `model_config.model` becomes the placeholder.

Adding the standard `__main__` guard makes Defilan's exact script work end-to-end with the unpatched wrapper:

```python
def main():
    llm = LLM(model="/path/to/local/Qwen3.6-35B-A3B-8bit", ..., additional_config={...})
    out = llm.generate(...)

if __name__ == "__main__":
    main()
```

I'll cover this in the issue comment so it's clear that's user-side, not a vllm-swift bug.

## Closes

- Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)