### PR TITLE
fix(vlm): Qwen3.5-VL vision pipeline (load order, token shape, mm_features)

### DIFF
--- a/swift/Sources/VLLMBridge/Bridge.swift
+++ b/swift/Sources/VLLMBridge/Bridge.swift
@@ -781,7 +781,11 @@ public func vsm_engine_prefill_vlm(
         guard let engine = engines[handle] else { return Int32(-1) }
 
         let tokens = (0..<Int(numTokens)).map { Int(promptTokens[$0]) }
-        let tokenArray = MLXArray(tokens)
+        // VLM forward path (e.g. mlx-swift-lm's MLXVLM/Qwen35) expects token
+        // ids in `[B, S]` shape, not flat `[S]`. embedTokens on a 1D input
+        // produces 2D `[S, H]`, which then crashes the linear-attention
+        // reshape that wants 3D `[B, S, H]`. Wrap to a batch of one here.
+        let tokenArray = MLXArray(tokens).reshaped(1, tokens.count)
 
         var params = engine.generateParams
         params.temperature = temperature

--- a/swift/Sources/VLLMBridge/Bridge.swift
+++ b/swift/Sources/VLLMBridge/Bridge.swift
@@ -183,24 +183,66 @@ public func vsm_engine_create(
     // Resolve symlinks: MLX's qwen3 path errors out on symlinked dirs.
     let modelURL = URL(fileURLWithPath: modelId).resolvingSymlinksInPath()
 
+    // Detect whether this model has a vision tower by inspecting config.json.
+    // For dual-registered model types (e.g. `qwen3_5`), `LLMModelFactory` will
+    // happily load a VL checkpoint as a text-only model, silently skipping the
+    // vision tower forward pass. That breaks image inputs (image-placeholder
+    // tokens get embedded as raw text). When `vision_config` (or any vision
+    // marker) is present in config.json, prefer the VLM factory; otherwise
+    // keep the LLM-first fast path that engages BatchedHybridLLM.
+    let isVisionModel: Bool = {
+        let cfgURL = modelURL.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: cfgURL),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        if obj["vision_config"] != nil { return true }
+        if let archs = obj["architectures"] as? [String] {
+            for a in archs {
+                let s = a.lowercased()
+                if s.contains("vl") || s.contains("vision") ||
+                   s.contains("conditionalgeneration") {
+                    return true
+                }
+            }
+        }
+        if let mt = obj["model_type"] as? String {
+            let m = mt.lowercased()
+            if m.contains("vl") || m.contains("vision") { return true }
+        }
+        return false
+    }()
+
     Task {
         do {
-            // Load via LLM factory first; the shared `loadModel(from:using:)`
-            // walks `ModelFactoryRegistry` which registers VLM before LLM, so
-            // dual-registered types (e.g. `qwen3_5`) would resolve to the VLM
-            // wrapper that doesn't conform to `BatchedHybridLLM` and bypass
-            // the batched-decode fast path. Fall back to VLM only on failure.
-            do {
-                result.context = try await MLXLLM.LLMModelFactory.shared.load(
-                    from: modelURL,
-                    using: StubTokenizerLoader()
-                )
-            } catch {
-                print("[vsm] LLM load failed, trying VLM: \(error.localizedDescription)")
-                result.context = try await MLXVLM.VLMModelFactory.shared.load(
-                    from: modelURL,
-                    using: StubTokenizerLoader()
-                )
+            if isVisionModel {
+                // VL-first path: load via VLMModelFactory so the vision tower
+                // forward + image-feature merge run.
+                do {
+                    result.context = try await MLXVLM.VLMModelFactory.shared.load(
+                        from: modelURL,
+                        using: StubTokenizerLoader()
+                    )
+                } catch {
+                    print("[vsm] VLM load failed, trying LLM: \(error.localizedDescription)")
+                    result.context = try await MLXLLM.LLMModelFactory.shared.load(
+                        from: modelURL,
+                        using: StubTokenizerLoader()
+                    )
+                }
+            } else {
+                // LLM-first fast path (unchanged): preserves BatchedHybridLLM.
+                do {
+                    result.context = try await MLXLLM.LLMModelFactory.shared.load(
+                        from: modelURL,
+                        using: StubTokenizerLoader()
+                    )
+                } catch {
+                    print("[vsm] LLM load failed, trying VLM: \(error.localizedDescription)")
+                    result.context = try await MLXVLM.VLMModelFactory.shared.load(
+                        from: modelURL,
+                        using: StubTokenizerLoader()
+                    )
+                }
             }
         } catch {
             result.error = error

--- a/vllm_swift/worker.py
+++ b/vllm_swift/worker.py
@@ -244,19 +244,40 @@ class SwiftMetalWorker:
             temp = getattr(sp, "temperature", 0.0)
             top_p = getattr(sp, "top_p", 1.0)
 
-            # Check for multimodal (VLM) inputs
-            # vLLM preprocesses images Python-side — mm_features has ready pixels
+            # Check for multimodal (VLM) inputs.
+            # vLLM preprocesses images Python-side. In vLLM v0.19+, `mm_features`
+            # is `list[MultiModalFeatureSpec]` (one per image/video item), not a
+            # single object. Use the static `gather_kwargs` helper to pull
+            # pixel_values / image_grid_thw out of all items.
             mm_features = getattr(new_req, "mm_features", None)
-            if mm_features and hasattr(mm_features, "pixel_values"):
-                pv = mm_features.pixel_values
+            mm_pv_kwargs = None
+            if mm_features:
+                try:
+                    from vllm.multimodal.inputs import MultiModalFeatureSpec as _MMFS
+                    mm_pv_kwargs = _MMFS.gather_kwargs(
+                        mm_features,
+                        {"pixel_values", "image_grid_thw"},
+                    )
+                except Exception:
+                    mm_pv_kwargs = None
+
+            if mm_pv_kwargs and mm_pv_kwargs.get("pixel_values"):
+                # gather_kwargs returns {key: list_of_tensors_per_item}.
+                # Concatenate per-item tensors along the patch axis (dim 0).
+                pv_items = mm_pv_kwargs["pixel_values"]
+                pv = pv_items[0] if len(pv_items) == 1 else torch.cat(pv_items, dim=0)
+                if hasattr(pv, "detach"):
+                    pv = pv.detach().to(torch.float32).cpu().contiguous()
                 if hasattr(pv, "numpy"):
                     pv = pv.numpy()
                 pixel_list = pv.flatten().tolist()
                 pixel_shape = list(pv.shape)
-                # Extract image_grid_thw if available
                 grid_thw = None
-                if hasattr(mm_features, "image_grid_thw"):
-                    g = mm_features.image_grid_thw
+                gthw_items = mm_pv_kwargs.get("image_grid_thw") or []
+                if gthw_items:
+                    g = gthw_items[0] if len(gthw_items) == 1 else torch.cat(gthw_items, dim=0)
+                    if hasattr(g, "detach"):
+                        g = g.detach().cpu().contiguous()
                     if hasattr(g, "numpy"):
                         g = g.numpy()
                     grid_thw = g.flatten().tolist()[:3]


### PR DESCRIPTION
Closes #16.

## Summary

Three coupled fixes that get end-to-end vision working in vllm-swift for Qwen3.5-VL models. Verified on Qwen3.5-9B-VL (`yaanfpv/Vayaan_9B_OmniClaw`, MLX 4-bit) with both real photographs and synthetic single-color test images.

## What was broken

Vision requests against Qwen3.5-VL models returned the same hallucinated description (often "a grid of Thai tone marks") for every input image, regardless of content. Diagnosis surfaced three sequential bugs:

1. **Python-side**: `mm_features` was treated as a single object via `hasattr(mm_features, "pixel_values")`, but vLLM v0.19+ delivers it as `list[MultiModalFeatureSpec]`. The check always returned `False`, so pixel data was silently dropped before reaching the FFI bridge.
2. **Swift-side load order**: `LLMModelFactory` accepts dual-registered VL types like `qwen3_5` and produces a text-only model with no vision forward path. Vision tower weights load but never run, so image-placeholder tokens reach the LM as raw text embeddings.
3. **Swift-side prefill shape**: `vsm_engine_prefill_vlm` passed token ids as a flat 1D `MLXArray`. Downstream, mlx-swift-lm's `MLXVLM/Qwen35.prepare` calls `embedTokens` which on a 1D input produces 2D `[S, H]`, then routes that into the language model where the gated-delta linear-attention reshape expects 3D `[B, S, H]` and crashes.

## Commits

| Hash | Subject |
|------|---------|
| `1cc8bec` | `fix(worker): handle mm_features as list[MultiModalFeatureSpec]` |
| `0800921` | `fix(bridge): load via VLMModelFactory when config has vision_config` |
| `a6c19ba` | `fix(bridge): reshape prefill_vlm tokenArray to [1, N] for mlx-vlm` |

Each commit body has the full reasoning, the visible symptom, and the verification model.

## Backward compatibility

Plain LLM models keep the original LLM-first fast path that engages `BatchedHybridLLM`. The new VL-first path only triggers when `config.json` has `vision_config`, or its architecture / model_type names match a vision marker.

## Test plan

- [x] Plain text `/v1/chat/completions` on Qwen3.5-9B-VL returns correct output
- [x] Vision `/v1/chat/completions` correctly describes a real photograph (Himalayan mountain landscape from Unsplash)
- [x] Vision `/v1/chat/completions` correctly identifies a synthetic solid-red PNG as red
- [x] No regression on plain LLM loading (LLMModelFactory still preferred when no vision_config)

## Notes

A separate issue thread is being filed for the `head_dim=256` Metal kernel coverage gap, which blocks TurboQuant on Qwen3.5 (the v0.6.0 metallib bottle is missing `turbo_dequant_rotated_*_256_*` even though the source instantiates them). That is independent of this PR.

Reported and patched by @YaanFPV.
